### PR TITLE
CLI: Accept `--api-key` argument

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ mod etherscan;
 #[command(name = "etherscan")]
 #[command(about = "A CLI to interact with etherscan", long_about = None)]
 struct Cli {
-    #[arg(short, long)]
+    #[arg(short, long, global = true)]
     api_key: Option<String>,
     #[command(subcommand)]
     command: Commands,


### PR DESCRIPTION
Refactors the etherscan mod to be a self contained library that can be initialized to contain the API key to decouple obtaining the key from actual library functionality. Now the flag can be obtained either from an ENV file or by passing in the `--api-key` flag.