### PR TITLE
URLs: build etherscan URLs instead of matching them

### DIFF
--- a/src/etherscan/mod.rs
+++ b/src/etherscan/mod.rs
@@ -3,7 +3,9 @@ use std::usize;
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 
-static ETHERSCAN_BASE_URL: &str = "https://api.etherscan.io/api";
+use crate::url::URLBuilder;
+
+static ETHERSCAN_BASE_URL: &str = "api.etherscan.io/api";
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GasResult {
@@ -53,11 +55,6 @@ struct EtherscanPriceResponse {
     result: Option<PriceResult>,
 }
 
-enum EtherscanApiRoute {
-    Gas,
-    Price,
-}
-
 #[derive(Default, Debug)]
 pub struct Etherscan {
     api_key: String,
@@ -68,21 +65,14 @@ impl Etherscan {
         Etherscan { api_key }
     }
 
-    fn build_etherscan_route(&self, route: EtherscanApiRoute) -> String {
-        match route {
-            EtherscanApiRoute::Gas => format!(
-                "{}?module=gastracker&action=gasoracle&apikey={}",
-                ETHERSCAN_BASE_URL, self.api_key
-            ),
-            EtherscanApiRoute::Price => format!(
-                "{}?module=stats&action=ethprice&apikey={}",
-                ETHERSCAN_BASE_URL, self.api_key
-            ),
-        }
-    }
-
     pub fn get_gas(&self) -> Result<GasResult> {
-        let url = self.build_etherscan_route(EtherscanApiRoute::Gas);
+        let url = URLBuilder::new()
+            .set_protocol("https")
+            .set_host(ETHERSCAN_BASE_URL)
+            .add_param("module", "gastracker")
+            .add_param("action", "gasoracle")
+            .add_param("apikey", &self.api_key)
+            .build();
 
         let res = reqwest::blocking::get(url)?.json::<EtherscanGasResponse>()?;
 
@@ -93,7 +83,13 @@ impl Etherscan {
     }
 
     pub fn get_eth_price(&self) -> Result<PriceResult> {
-        let url = self.build_etherscan_route(EtherscanApiRoute::Price);
+        let url = URLBuilder::new()
+            .set_protocol("http")
+            .set_host(ETHERSCAN_BASE_URL)
+            .add_param("module", "stats")
+            .add_param("action", "ethprice")
+            .add_param("apikey", &self.api_key)
+            .build();
 
         let res = reqwest::blocking::get(url)?.json::<EtherscanPriceResponse>()?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use dotenv::{dotenv, var};
 use ethers::core::types::H160;
 
 mod etherscan;
+mod url;
 
 #[derive(Debug, Parser)]
 #[command(name = "etherscan")]

--- a/src/url.rs
+++ b/src/url.rs
@@ -1,0 +1,144 @@
+use std::collections::HashMap;
+
+pub struct URLBuilder {
+    protocol: String,
+    host: String,
+    port: u16,
+    params: HashMap<String, String>,
+}
+
+impl URLBuilder {
+    pub fn new() -> URLBuilder {
+        URLBuilder {
+            protocol: String::new(),
+            host: String::new(),
+            port: 0,
+            params: HashMap::new(),
+        }
+    }
+
+    pub fn build(&self) -> String {
+        let base = format!("{}://{}", self.protocol, self.host);
+
+        let mut url_params = String::new();
+
+        if !self.params.is_empty() {
+            url_params.push('?');
+
+            for (param, value) in self.params.iter() {
+                url_params.push_str(format!("{}={}&", param, value).as_str());
+            }
+        }
+
+        match self.port {
+            0 => format!("{}{}", base, url_params),
+            _ => format!("{}:{}{}", base, self.port, url_params),
+        }
+    }
+
+    pub fn add_param(&mut self, param: &str, value: &str) -> &mut Self {
+        self.params.insert(param.to_string(), value.to_string());
+
+        self
+    }
+
+    pub fn set_protocol(&mut self, protocol: &str) -> &mut Self {
+        self.protocol = protocol.to_string();
+
+        self
+    }
+
+    pub fn set_host(&mut self, host: &str) -> &mut Self {
+        self.host = host.to_string();
+
+        self
+    }
+
+    pub fn set_port(&mut self, port: u16) -> &mut Self {
+        self.port = port;
+
+        self
+    }
+
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    pub fn host(&self) -> &str {
+        &self.host
+    }
+
+    pub fn protocol(&self) -> &str {
+        &self.protocol
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_set_host() {
+        let mut ub = URLBuilder::new();
+        ub.set_host("localhost");
+        assert_eq!("localhost", ub.host());
+    }
+
+    #[test]
+    fn test_set_protocol() {
+        let mut ub = URLBuilder::new();
+        ub.set_protocol("https");
+        assert_eq!("https", ub.protocol());
+    }
+
+    #[test]
+    fn test_set_port() {
+        let mut ub = URLBuilder::new();
+        ub.set_port(8000);
+        assert_eq!(8000, ub.port());
+    }
+
+    #[test]
+    fn create_google_url() {
+        let mut ub = URLBuilder::new();
+        ub.set_protocol("http")
+            .set_host("www.google.com")
+            .set_port(80);
+        let url = ub.build();
+        assert_eq!("http://www.google.com:80", url);
+    }
+
+    #[test]
+    fn create_url_without_port() {
+        let mut ub = URLBuilder::new();
+        ub.set_protocol("http").set_host("google.com");
+        let url = ub.build();
+        assert_eq!("http://google.com", url)
+    }
+
+    #[test]
+    fn create_url_without_port_and_params() {
+        let mut ub = URLBuilder::new();
+        ub.set_protocol("http")
+            .set_host("google.com")
+            .add_param("gcookie", "0xcafe");
+        let url = ub.build();
+        assert_eq!("http://google.com?gcookie=0xcafe&", url)
+    }
+
+    #[test]
+    fn create_url_with_params() {
+        let mut ub = URLBuilder::new();
+        ub.set_protocol("http")
+            .set_host("localhost")
+            .set_port(8000)
+            .add_param("first", "1")
+            .add_param("second", "2")
+            .add_param("third", "3");
+
+        let url = ub.build();
+        assert!(url.contains("first=1"));
+        assert!(url.contains("second=2"));
+        assert!(url.contains("third=3"));
+    }
+}


### PR DESCRIPTION
Adds a new `URLBuilder` to build well-formatted URLs, which is then used to build the etherscan URLs instead of doing awkward formatting tricks with them. Ideally `URLBuilder` would be moved to its own crate later as it's an useful utility on its own.