### PR TITLE
Commands: Generalize `balance` to also fetch ERC20 tokens

### DIFF
--- a/src/etherscan/mod.rs
+++ b/src/etherscan/mod.rs
@@ -110,4 +110,32 @@ impl Etherscan {
             )),
         }
     }
+
+    pub fn get_token_balance(&self, address: H160, token_address: H160) -> Result<String> {
+        let url = URLBuilder::new()
+            .set_protocol("https")
+            .set_host(ETHERSCAN_BASE_URL)
+            .add_param("module", "account")
+            .add_param("action", "tokenbalance")
+            .add_param(
+                "address",
+                &format!("0x{}", hex::encode(address.to_fixed_bytes())),
+            )
+            .add_param(
+                "contractaddress",
+                &format!("0x{}", hex::encode(token_address.to_fixed_bytes())),
+            )
+            .add_param("tag", "latest")
+            .add_param("apikey", &self.api_key)
+            .build();
+
+        let res = reqwest::blocking::get(url)?.json::<EtherscanApiResponse<String>>()?;
+
+        match res.result {
+            Some(eth_balance) => Ok(eth_balance),
+            None => Err(anyhow!(
+                "Could not fetch eth balance for the account specified"
+            )),
+        }
+    }
 }

--- a/src/etherscan/mod.rs
+++ b/src/etherscan/mod.rs
@@ -87,55 +87,43 @@ impl Etherscan {
         }
     }
 
-    pub fn get_eth_balance(&self, address: H160) -> Result<String> {
-        let url = URLBuilder::new()
-            .set_protocol("https")
-            .set_host(ETHERSCAN_BASE_URL)
-            .add_param("module", "account")
-            .add_param("action", "balance")
-            .add_param(
-                "address",
-                &format!("0x{}", hex::encode(address.to_fixed_bytes())),
-            )
-            .add_param("tag", "latest")
-            .add_param("apikey", &self.api_key)
-            .build();
+    pub fn get_balance(&self, address: H160, token_address: Option<H160>) -> Result<String> {
+        let url = match token_address {
+            None => URLBuilder::new()
+                .set_protocol("https")
+                .set_host(ETHERSCAN_BASE_URL)
+                .add_param("module", "account")
+                .add_param("action", "balance")
+                .add_param(
+                    "address",
+                    &format!("0x{}", hex::encode(address.to_fixed_bytes())),
+                )
+                .add_param("tag", "latest")
+                .add_param("apikey", &self.api_key)
+                .build(),
+            Some(token_address) => URLBuilder::new()
+                .set_protocol("https")
+                .set_host(ETHERSCAN_BASE_URL)
+                .add_param("module", "account")
+                .add_param("action", "tokenbalance")
+                .add_param(
+                    "address",
+                    &format!("0x{}", hex::encode(address.to_fixed_bytes())),
+                )
+                .add_param(
+                    "contractaddress",
+                    &format!("0x{}", hex::encode(token_address.to_fixed_bytes())),
+                )
+                .add_param("tag", "latest")
+                .add_param("apikey", &self.api_key)
+                .build(),
+        };
 
         let res = reqwest::blocking::get(url)?.json::<EtherscanApiResponse<String>>()?;
 
         match res.result {
-            Some(eth_balance) => Ok(eth_balance),
-            None => Err(anyhow!(
-                "Could not fetch eth balance for the account specified"
-            )),
-        }
-    }
-
-    pub fn get_token_balance(&self, address: H160, token_address: H160) -> Result<String> {
-        let url = URLBuilder::new()
-            .set_protocol("https")
-            .set_host(ETHERSCAN_BASE_URL)
-            .add_param("module", "account")
-            .add_param("action", "tokenbalance")
-            .add_param(
-                "address",
-                &format!("0x{}", hex::encode(address.to_fixed_bytes())),
-            )
-            .add_param(
-                "contractaddress",
-                &format!("0x{}", hex::encode(token_address.to_fixed_bytes())),
-            )
-            .add_param("tag", "latest")
-            .add_param("apikey", &self.api_key)
-            .build();
-
-        let res = reqwest::blocking::get(url)?.json::<EtherscanApiResponse<String>>()?;
-
-        match res.result {
-            Some(eth_balance) => Ok(eth_balance),
-            None => Err(anyhow!(
-                "Could not fetch eth balance for the account specified"
-            )),
+            Some(balance) => Ok(balance),
+            None => Err(anyhow!("Could not fetch balance for the account specified")),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,53 +79,54 @@ fn main() {
                 println!("{}", err);
             }
         },
-        Commands::Account(account) => {
-            match account.command {
-                Some(AccountCommands::Balance {
-                    address,
-                    token,
-                    decimals,
-                }) => {
-                    let (balance, token_name) = match token {
-                        None => (
-                            etherscan.get_eth_balance(address).unwrap(),
-                            "ETH".to_string(),
-                        ),
-                        Some(ticker) => {
-                            if ticker.to_lowercase() == "eth" {
-                                (
-                                    etherscan.get_eth_balance(address).unwrap(),
-                                    "ETH".to_string(),
-                                )
-                            } else {
-                                (
-                                    etherscan
-                                        .get_token_balance(
-                                            address,
+        Commands::Account(account) => match account.command {
+            Some(AccountCommands::Balance {
+                address,
+                token,
+                decimals,
+            }) => {
+                let (balance, token_name) = match token {
+                    None => (
+                        etherscan.get_balance(address, None).unwrap(),
+                        "ETH".to_string(),
+                    ),
+                    Some(ticker) => {
+                        if ticker.to_lowercase() == "eth" {
+                            (
+                                etherscan.get_balance(address, None).unwrap(),
+                                "ETH".to_string(),
+                            )
+                        } else {
+                            (
+                                etherscan
+                                    .get_balance(
+                                        address,
+                                        Some(
                                             ethers::addressbook::contract(&ticker.to_lowercase())
                                                 .expect("Invalid token name")
                                                 .address(ethers::types::Chain::Mainnet)
                                                 .unwrap(),
-                                        )
-                                        .unwrap(),
-                                    ticker,
-                                )
-                            }
-                        }
-                    };
-
-                    match decimals {
-                        None => {
-                            let parsed_balance =
-                                ethers::core::utils::parse_units(balance, "wei").unwrap();
-                            println!(
-                                "{} Balance: {}",
-                                token_name,
-                                ethers::core::utils::format_units(parsed_balance, "ether").unwrap(),
+                                        ),
+                                    )
+                                    .unwrap(),
+                                ticker,
                             )
                         }
-                        Some(decimals) => {
-                            println!(
+                    }
+                };
+
+                match decimals {
+                    None => {
+                        let parsed_balance =
+                            ethers::core::utils::parse_units(balance, "wei").unwrap();
+                        println!(
+                            "{} Balance: {}",
+                            token_name,
+                            ethers::core::utils::format_units(parsed_balance, "ether").unwrap(),
+                        )
+                    }
+                    Some(decimals) => {
+                        println!(
                             "{} balance: {}",
                             token_name,
                             ethers::core::utils::format_units(
@@ -133,13 +134,14 @@ fn main() {
                                     .expect("Malformed balance input from Etherscan"),
                                 decimals
                             )
-                            .expect("Could not format units properly. Did you input valid decimals?")
+                            .expect(
+                                "Could not format units properly. Did you input valid decimals?"
+                            )
                         );
-                        }
                     }
                 }
-                _ => todo!(),
             }
-        }
+            _ => todo!(),
+        },
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,18 +91,27 @@ fn main() {
                             etherscan.get_eth_balance(address).unwrap(),
                             "ETH".to_string(),
                         ),
-                        Some(ticker) => (
-                            etherscan
-                                .get_token_balance(
-                                    address,
-                                    ethers::addressbook::contract(&ticker.to_lowercase())
-                                        .expect("Invalid token name")
-                                        .address(ethers::types::Chain::Mainnet)
-                                        .unwrap(),
+                        Some(ticker) => {
+                            if ticker.to_lowercase() == "eth" {
+                                (
+                                    etherscan.get_eth_balance(address).unwrap(),
+                                    "ETH".to_string(),
                                 )
-                                .unwrap(),
-                            ticker,
-                        ),
+                            } else {
+                                (
+                                    etherscan
+                                        .get_token_balance(
+                                            address,
+                                            ethers::addressbook::contract(&ticker.to_lowercase())
+                                                .expect("Invalid token name")
+                                                .address(ethers::types::Chain::Mainnet)
+                                                .unwrap(),
+                                        )
+                                        .unwrap(),
+                                    ticker,
+                                )
+                            }
+                        }
                     };
 
                     match decimals {

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,12 +117,14 @@ fn main() {
 
                 match decimals {
                     None => {
-                        let parsed_balance =
-                            ethers::core::utils::parse_units(balance, "wei").unwrap();
                         println!(
                             "{} Balance: {}",
                             token_name,
-                            ethers::core::utils::format_units(parsed_balance, "ether").unwrap(),
+                            ethers::core::utils::format_units(
+                                U256::from_dec_str(&balance).unwrap(),
+                                "ether"
+                            )
+                            .unwrap(),
                         )
                     }
                     Some(decimals) => {


### PR DESCRIPTION
Note that this uses the ether's addressbook, which admitedly is very limited. Should probably add a custom tokenlist to draw tickers/addresses from.